### PR TITLE
Looser compatibility bound for Julia

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ JuMP = "0.21.3"
 PyCall = "1.91.4"
 PyPlot = "2.9.0"
 Revise = "2.7.3"
-julia = "1.4"
+julia = "^1.3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
The package works on `v1.3` (that's the version we test on) and above. `~1.3` means `1.3`, `1.4`, `1.5`, ..., excluding `2.0` and above.